### PR TITLE
fix NPE in componentWillReceiveProps on line 150

### DIFF
--- a/SortableSudokuGrid.js
+++ b/SortableSudokuGrid.js
@@ -147,7 +147,7 @@ class SortableSudokuGrid extends Component {
             !newState && (newState = {})
             newState.dataSource = dataSource
         }
-        newState.containerHeight= this.createHeight(nextProps),
+        newState && (newState.containerHeight= this.createHeight(nextProps)),
         newState && this.setState(newState)
     }
 


### PR DESCRIPTION
The component was failing on line 150. The following line 

newState.containerHeight= this.createHeight(nextProps)

was failing as newState was still unassigned. The fix is to check for validity of newState before assignment.