### PR TITLE
fix prop-types for react native 0.49

### DIFF
--- a/SortableCell.js
+++ b/SortableCell.js
@@ -1,7 +1,7 @@
 import React, {
-    PropTypes,
     Component,
 } from 'react'
+import PropTypes from 'prop-types';
 import {
     View, Text,
     StyleSheet,

--- a/SortableSudokuGrid.js
+++ b/SortableSudokuGrid.js
@@ -6,9 +6,9 @@
  */
 
 import React, {
-    PropTypes,
     Component,
 } from 'react'
+import PropTypes from 'prop-types';
 import {
     View,
     StyleSheet,

--- a/SortableSudokuGrid.js
+++ b/SortableSudokuGrid.js
@@ -51,6 +51,7 @@ class SortableSudokuGrid extends Component {
         dataSource: PropTypes.array.isRequired,
         renderCell: PropTypes.func.isRequired,
         sortable: PropTypes.bool,
+        onResort: PropTypes.func,
     }
 
     createHeight(props){
@@ -535,6 +536,10 @@ class SortableSudokuGrid extends Component {
         this.setState({
             dataSource,
         })
+
+        if (this.props.onResort) {
+            this.props.onResort(dataSource)
+        }
     }
 
     _removeData = (cellIndex) => {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/react-native-component/react-native-smart-sortable-sudoku-grid#readme",
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react-native-smart-timer-enhance": "^1.0.2"
   }
 }


### PR DESCRIPTION
This PR removes the deprecated dependency on PropTypes and uses the recommended prop-types package instead.