### PR TITLE
Fixed layout when screen orientation changed to support horizon orientation.

### DIFF
--- a/SortableCell.js
+++ b/SortableCell.js
@@ -66,6 +66,12 @@ export default class SortableCell extends Component {
         )
     }
 
+    componentWillReceiveProps({coordinate: {x, y}}) {
+        if (x !== this.state.coordinate.x._value || y !== this.state.coordinate.y._value) {
+            this.setCoordinate({x, y});
+        }
+    }
+
     componentWillUnmount () {
         this._stopScaleAnmation()
     }


### PR DESCRIPTION
Hi, I have fixed the layout issue when screen orientation changed, now horizon orientation is supported.

The most important code is the parent component will change rowWidth when orientation changed, so componentWillReceiveProps will handle it.

BTW: state.sortable can be replace with props.sortable so that the sortable control will belong to parent component totally.

**The patch is just a part of my code, because I have no the example app, please have a test.**